### PR TITLE
Refactor Credentials class for better secret handling

### DIFF
--- a/backend/layers/openid-auth/openid_auth.py
+++ b/backend/layers/openid-auth/openid_auth.py
@@ -1,24 +1,40 @@
+import json
 from datetime import datetime, timedelta
-import boto3
 import requests
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 
 
 class Credentials:
     def __init__(
         self,
-        token_url: str,
-        client_id: str,
         scopes: list[str],
-        user_pool_id: str = None,
+        token_url: str = None,
+        client_id: str = None,
         client_secret: str = None,
+        user_pool_id: str = None,
+        secret_arn: str = None,
     ) -> None:
+        if sum((bool(client_secret), bool(user_pool_id), bool(secret_arn))) != 1:
+            raise ValueError(
+                "Exactly one of client_secret, user_pool_id or secret_arn must be provided"
+            )
         self._token_url = token_url
         self._user_pool_id = user_pool_id
         self._client_id = client_id
         self._scope = " ".join(scopes)
         self._client_secret = client_secret
+        self._secret_arn = secret_arn
         self._access_token = None
         self._expires_at = None
+
+        if self._secret_arn:
+            self._get_secret_values()
+        elif self._user_pool_id:
+            self._get_client_secret()
+
+        if not self._client_secret or not self._token_url or not self._client_id:
+            raise ValueError("Failed to obtain required credentials")
 
     def token(self) -> str:
         if (
@@ -26,21 +42,37 @@ class Credentials:
             or self._expires_at is None
             or (self._expires_at and self._expires_at < datetime.now())
         ):
-            if not self._client_secret:
-                self._get_client_secret()
             self._request_token()
         return self._access_token
 
     def _get_client_secret(self):
         """Get client secret from Cognito"""
-        if self._user_pool_id is None:
-            raise ValueError("Either client_secret or user_pool_id must be provided")
+        try:
+            client = boto3.client("cognito-idp")
+            user_pool_client = client.describe_user_pool_client(
+                UserPoolId=self._user_pool_id, ClientId=self._client_id
+            )
+            self._client_secret = user_pool_client["UserPoolClient"]["ClientSecret"]
+        except (BotoCoreError, ClientError):
+            return
 
-        client = boto3.client("cognito-idp")
-        user_pool_client = client.describe_user_pool_client(
-            UserPoolId=self._user_pool_id, ClientId=self._client_id
-        )
-        self._client_secret = user_pool_client["UserPoolClient"]["ClientSecret"]
+    def _get_secret_values(self):
+        """Get secret value from Secrets Manager"""
+        try:
+            client = boto3.client("secretsmanager")
+            secret_response = client.get_secret_value(SecretId=self._secret_arn)
+        except (BotoCoreError, ClientError):
+            return
+        secret_string = secret_response.get("SecretString")
+        if not secret_string:
+            raise ValueError("Secret value not found for secret")
+        try:
+            secret_data = json.loads(secret_string)
+            self._token_url = secret_data.get("authorization_endpoint")
+            self._client_id = secret_data.get("client_id")
+            self._client_secret = secret_data.get("client_secret")
+        except json.JSONDecodeError as e:
+            raise ValueError("Secret value not valid json") from e
 
     def _request_token(self):
         """Request access token"""


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
The OAuth Lambda Layer was created to centralise the function of retrieving OAuth client credentials grant token from an OAuth Endpoint. It also handles caching and refresh.

It was created with 2 use cases in mind. Supply the client_secret and use that OR supply the Cognito User Pool Id instead to programmatically retrieve the client_secret so it was not being stored in env variables etc.

I now want to expand this to handle non-Cognito providers and for them the plan will be to store the details in a Secrets Manager Secret so now this class needs to be able to retrieve the values from the secret instead. I have chosen to makes the secret value required to be json and may hold more than just the client_secret. This will make the secret re-usable by Event Bridge connections but means some on the previously required parameters (token_url and client_id) may come from the Secret so are no longer required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
