### PR TITLE
Fallback to AWS SDK credential chain in envValues

### DIFF
--- a/frontend/scripts/envValues.js
+++ b/frontend/scripts/envValues.js
@@ -23,12 +23,12 @@ async function parseToml(tomlPath, env) {
     })
   );
   const result = {
-    profile: tomlParameters.profile ?? "default",
+    profile: tomlParameters.profile || null,
     region: tomlParameters.region,
     apiStackName: parameterOverrides.ApiStackName,
     toolsStackName: tomlParameters.stack_name,
   };
-  if (Object.values(result).some((v) => !v)) {
+  if ([result.region, result.apiStackName, result.toolsStackName].some((v) => !v)) {
     console.log(
       chalk.yellow(
         "Unable to find Region and/or Stack Name(s) in specified toml."
@@ -77,7 +77,7 @@ async function readToml(tomlPath) {
 async function getCloudFormationOutputs(profile, region, stackName) {
   const cfnClient = new CloudFormationClient({
     region: region,
-    credentials: fromIni({ profile }),
+    ...(profile && { credentials: fromIni({ profile }) }),
   });
   const describeStacks = new DescribeStacksCommand({ StackName: stackName });
   try {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When no profile is specified in samconfig.toml, let the AWS SDK use its default credential provider chain instead of explicitly looking for a "default" profile. This respects AWS_PROFILE env var, default profile in ~/.aws/config, and other standard credential sources.

If a profile is explicitly set in samconfig.toml, it takes precedence.

I hit this problem following the setup instructions at the step of run envLocal.js, SAM hadn't written a named profile to the samconfig.toml. I configure the AWS named profile using the AWS_PROFILE environment variable[1]. I think it makes more sense to support this convention than require editing the sam config.

1. https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#:~:text=AWS%5FPROFILE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
